### PR TITLE
bitbang: Fix FTBFS with GCC 10

### DIFF
--- a/src/jtag/drivers/bitbang.h
+++ b/src/jtag/drivers/bitbang.h
@@ -35,7 +35,7 @@ struct bitbang_interface {
 	void (*swdio_drive)(bool on);
 };
 
-const struct swd_driver bitbang_swd;
+extern const struct swd_driver bitbang_swd;
 
 extern bool swd_mode;
 

--- a/tcl/interface/raspberrypi4-native.cfg
+++ b/tcl/interface/raspberrypi4-native.cfg
@@ -1,0 +1,23 @@
+#
+# Config sourced from:
+# https://github.com/pok3r-custom/pok3r_re_firmware/issues/23#issuecomment-830785367
+#
+
+interface bcm2835gpio
+
+debug_level 2
+adapter_khz 1
+
+# (config for pi4)
+bcm2835gpio_peripheral_base 0xFE000000
+bcm2835gpio_speed_coeffs 236181 60
+
+# Each of the SWD lines need a gpio number set: swclk swdio
+# (use pinout.xyz, those are pins 38 and 40)
+bcm2835gpio_swd_nums 20 21
+
+# (pin 12 on the PI)
+bcm2835gpio_srst_num 18
+
+# (don't forget pin 9 for Ground)
+transport select swd


### PR DESCRIPTION
This is required to build `openocd-ht32` with a recent version of GCC.
--------------------------------------------------------------------------------------------
GCC 10 defaults to -fno-common which breaks the sharing of bitbang_swd struct between bitbang drivers due to a missing extern.

Change-Id: I2b4122f7939cec91a72284006748f99a23548324
Signed-off-by: Andreas Fritiofson <andreas.fritiofson@gmail.com>
Reviewed-on: http://openocd.zylin.com/5592
Tested-by: jenkins
Reviewed-by: Antonio Borneo <borneo.antonio@gmail.com>
Reviewed-by: Jonathan McDowell <noodles-openocd@earth.li>